### PR TITLE
Add cell tooltip for usability

### DIFF
--- a/ProjectConfigurationManager.View/CellToToolTipConverter.cs
+++ b/ProjectConfigurationManager.View/CellToToolTipConverter.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.Contracts;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using tomenglertde.ProjectConfigurationManager.Model;
+
+namespace tomenglertde.ProjectConfigurationManager.View
+{
+    class CellToToolTipConverter : IValueConverter, IMultiValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            var propertyText = "";
+            var configText = "";
+
+            var cell = value as DataGridCell;
+
+            var projectConfiguration = cell.DataContext as ProjectConfiguration;
+            if (projectConfiguration != null)
+            {
+                configText = string.Format("{0} {1} {2}", projectConfiguration.Project.Name, projectConfiguration.Configuration, projectConfiguration.Platform);
+            }
+
+            var column = cell?.Column;
+            if (column != null)
+            {
+                var propertyName = (ProjectPropertyName)cell.Column.GetValue(ProperitesColumnsMananger.ProjectConfigurationProperty);
+                if (propertyName != null)
+                {
+                    propertyText = propertyName.DisplayName;
+                }
+            }
+
+            return configText + Environment.NewLine + propertyText;
+        }
+
+        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+        {
+            return Convert(values?.OfType<DataGridCell>().FirstOrDefault(), targetType, parameter, culture);
+        }
+
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/ProjectConfigurationManager.View/ProjectConfigurationManager.View.csproj
+++ b/ProjectConfigurationManager.View/ProjectConfigurationManager.View.csproj
@@ -29,13 +29,20 @@
     <CodeContractsFailBuildOnWarnings>False</CodeContractsFailBuildOnWarnings>
     <CodeContractsSkipAnalysisIfCannotConnectToCache>False</CodeContractsSkipAnalysisIfCannotConnectToCache>
     <CodeContractsCacheAnalysisResults>True</CodeContractsCacheAnalysisResults>
-    <CodeContractsBaseLineFile></CodeContractsBaseLineFile>
-    <CodeContractsSQLServerOption></CodeContractsSQLServerOption>
-    <CodeContractsExtraAnalysisOptions></CodeContractsExtraAnalysisOptions>
-    <CodeContractsExtraRewriteOptions></CodeContractsExtraRewriteOptions>
-    <CodeContractsLibPaths></CodeContractsLibPaths>
-    <CodeContractsCustomRewriterClass></CodeContractsCustomRewriterClass>
-    <CodeContractsCustomRewriterAssembly></CodeContractsCustomRewriterAssembly>
+    <CodeContractsBaseLineFile>
+    </CodeContractsBaseLineFile>
+    <CodeContractsSQLServerOption>
+    </CodeContractsSQLServerOption>
+    <CodeContractsExtraAnalysisOptions>
+    </CodeContractsExtraAnalysisOptions>
+    <CodeContractsExtraRewriteOptions>
+    </CodeContractsExtraRewriteOptions>
+    <CodeContractsLibPaths>
+    </CodeContractsLibPaths>
+    <CodeContractsCustomRewriterClass>
+    </CodeContractsCustomRewriterClass>
+    <CodeContractsCustomRewriterAssembly>
+    </CodeContractsCustomRewriterAssembly>
     <CodeContractsEmitXMLDocs>False</CodeContractsEmitXMLDocs>
     <CodeContractsUseBaseLine>False</CodeContractsUseBaseLine>
     <CodeContractsShowSquigglies>True</CodeContractsShowSquigglies>
@@ -79,13 +86,20 @@
     <CodeContractsFailBuildOnWarnings>False</CodeContractsFailBuildOnWarnings>
     <CodeContractsSkipAnalysisIfCannotConnectToCache>False</CodeContractsSkipAnalysisIfCannotConnectToCache>
     <CodeContractsCacheAnalysisResults>True</CodeContractsCacheAnalysisResults>
-    <CodeContractsBaseLineFile></CodeContractsBaseLineFile>
-    <CodeContractsSQLServerOption></CodeContractsSQLServerOption>
-    <CodeContractsExtraAnalysisOptions></CodeContractsExtraAnalysisOptions>
-    <CodeContractsExtraRewriteOptions></CodeContractsExtraRewriteOptions>
-    <CodeContractsLibPaths></CodeContractsLibPaths>
-    <CodeContractsCustomRewriterClass></CodeContractsCustomRewriterClass>
-    <CodeContractsCustomRewriterAssembly></CodeContractsCustomRewriterAssembly>
+    <CodeContractsBaseLineFile>
+    </CodeContractsBaseLineFile>
+    <CodeContractsSQLServerOption>
+    </CodeContractsSQLServerOption>
+    <CodeContractsExtraAnalysisOptions>
+    </CodeContractsExtraAnalysisOptions>
+    <CodeContractsExtraRewriteOptions>
+    </CodeContractsExtraRewriteOptions>
+    <CodeContractsLibPaths>
+    </CodeContractsLibPaths>
+    <CodeContractsCustomRewriterClass>
+    </CodeContractsCustomRewriterClass>
+    <CodeContractsCustomRewriterAssembly>
+    </CodeContractsCustomRewriterAssembly>
     <CodeContractsEmitXMLDocs>False</CodeContractsEmitXMLDocs>
     <CodeContractsUseBaseLine>False</CodeContractsUseBaseLine>
     <CodeContractsShowSquigglies>True</CodeContractsShowSquigglies>
@@ -178,6 +192,7 @@
     <Compile Include="..\Version.cs">
       <Link>Properties\Version.cs</Link>
     </Compile>
+    <Compile Include="CellToToolTipConverter.cs" />
     <Compile Include="DataGridTryBeginEditBehavior.cs" />
     <Compile Include="ProjectTypeGuidToDisplayNameConverter.cs" />
     <Compile Include="ProperitesColumnsMananger.cs" />

--- a/ProjectConfigurationManager.View/PropertiesView.xaml
+++ b/ProjectConfigurationManager.View/PropertiesView.xaml
@@ -13,6 +13,7 @@
 
   <UserControl.Resources>
     <local:CellToBackgroundBrushConverter x:Key="CellToBackgroundBrushConverter" />
+    <local:CellToToolTipConverter x:Key="CellToToolTipConverter" />
     <local:ProjectTypeGuidToDisplayNameConverter x:Key="ProjectTypeGuidToDisplayNameConverter" />
     <CollectionViewSource x:Key="PropertiesSource" Source="{Binding Solution.ProjectProperties}">
       <CollectionViewSource.GroupDescriptions>
@@ -137,7 +138,15 @@
       </DataGrid.Columns>
       <DataGrid.CellStyle>
         <Style TargetType="DataGridCell">
-          <Setter Property="BorderThickness" Value="2" />
+          <Setter Property="ToolTip">
+              <Setter.Value>
+                  <MultiBinding Converter="{StaticResource CellToToolTipConverter}">
+                      <Binding RelativeSource="{RelativeSource Self}" />
+                      <Binding />
+                  </MultiBinding>
+              </Setter.Value>
+          </Setter>
+        <Setter Property="BorderThickness" Value="2" />
           <Setter Property="Background">
             <Setter.Value>
               <MultiBinding Converter="{StaticResource CellToBackgroundBrushConverter}">


### PR DESCRIPTION
Show configuration and property details in cell tooltip to save a lot of
mouse movement. Helps avoid mistakenly changing the wrong setting when
the property grid is dense.
